### PR TITLE
build(wsl): Running gtest successfully

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -4,7 +4,8 @@
             "name": "Linux",
             "includePath": [
                 "${workspaceFolder}/**",
-                "${workspaceFolder}/googletest-release-1.8.0/*"
+                "${workspaceFolder}/googletest-release-1.12.1/*",
+                "${workspaceFolder}/inc/*"
             ],
             "defines": [],
             "compilerPath": "/usr/bin/clang",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,12 +7,11 @@ set (CMAKE_CXX_EXTENSIONS OFF)
 set (CMAKE_EXPORT_COMPILE_COMMANDS ON) 
 
 add_library (calculator STATIC calculator.cpp)
-target_include_directories (calculator PRIVATE inc/)
+target_include_directories (calculator PUBLIC inc/)
 
 add_subdirectory(googletest-release-1.12.1)
 
 add_executable (test-calculator test-calculator.cpp)
-target_link_libraries (test-calculator PRIVATE calculator gtest 
-gtest_main)
+target_link_libraries (test-calculator PRIVATE calculator gtest gtest_main)
 
 

--- a/calculator.cpp
+++ b/calculator.cpp
@@ -1,3 +1,5 @@
-int main () {
-    
+#include "calculator.h"
+
+int calculator::add (int param1, int param2){
+    return param1 + param2;
 }

--- a/test-calculator.cpp
+++ b/test-calculator.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
-  
-TEST(Calculator, Fail)
+#include "calculator.h"
+
+TEST(Calculator, Add)
 {
-  EXPECT_TRUE(0);
+  EXPECT_EQ(5, calculator::add(2, 3));
 }


### PR DESCRIPTION
Tested addition functionality, fixed issues regarding namespace as bad practice pulling entire namespace in via `using calculator`. Instead writing `calculator::add ` ie namespace before function being used.

Also in the CMakeLists.txt changed `target_include_directories (calculator PRIVATE inc/)` to
`target_include_directories (calculator PUBLIC inc/)` as we want the header file in inc to be used by both the test and calcuator.cpp. Ideally we would like it to be both `PRIVATE` and `INTERFACE` but CMake doesn't have this option so we have to choose `PUBLIC`